### PR TITLE
STYLE: Use Macro for Function Deletion

### DIFF
--- a/include/itkLabelSetDilateImageFilter.h
+++ b/include/itkLabelSetDilateImageFilter.h
@@ -84,8 +84,7 @@ protected:
   void ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId) ITK_OVERRIDE;
 
 private:
-  LabelSetDilateImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);            //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(LabelSetDilateImageFilter);
 
   typedef typename Superclass::DistanceImageType DistanceImageType;
 };

--- a/include/itkLabelSetErodeImageFilter.h
+++ b/include/itkLabelSetErodeImageFilter.h
@@ -90,8 +90,7 @@ protected:
 
   // Override since the filter produces the entire dataset.
 private:
-  LabelSetErodeImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);           //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(LabelSetErodeImageFilter);
 
   typedef typename Superclass::DistanceImageType DistanceImageType;
 };

--- a/include/itkLabelSetMorphBaseImageFilter.h
+++ b/include/itkLabelSetMorphBaseImageFilter.h
@@ -144,8 +144,7 @@ protected:
   // support elliptical operations
   RealType m_BaseSigma;
 private:
-  LabelSetMorphBaseImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);               //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(LabelSetMorphBaseImageFilter);
 };
 } // end namespace itk
 


### PR DESCRIPTION
Use ITK_DISALLOW_COPY_AND_ASSIGN macro to delete copy and assignment constructors which uses c++11's rigorous delete on compilers that support it.
