### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkLabelSetDilateImageFilter.h
+++ b/include/itkLabelSetDilateImageFilter.h
@@ -42,6 +42,8 @@ class ITK_EXPORT LabelSetDilateImageFilter:
   public LabelSetMorphBaseImageFilter< TInputImage, true, TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(LabelSetDilateImageFilter);
+
   /** Standard class type alias. */
   using Self = LabelSetDilateImageFilter;
   using Superclass = LabelSetMorphBaseImageFilter< TInputImage, true, TOutputImage >;
@@ -81,9 +83,6 @@ protected:
   void ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId) override;
 
 private:
-  LabelSetDilateImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);            //purposely not implemented
-
   using DistanceImageType = typename Superclass::DistanceImageType;
 };
 } // end namespace itk

--- a/include/itkLabelSetErodeImageFilter.h
+++ b/include/itkLabelSetErodeImageFilter.h
@@ -44,6 +44,8 @@ class ITK_EXPORT LabelSetErodeImageFilter:
   public LabelSetMorphBaseImageFilter< TInputImage, false, TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(LabelSetErodeImageFilter);
+
   /** Standard class type alias. */
   using Self = LabelSetErodeImageFilter;
   using Superclass = LabelSetMorphBaseImageFilter< TInputImage, false, TOutputImage >;
@@ -87,9 +89,6 @@ protected:
 
   // Override since the filter produces the entire dataset.
 private:
-  LabelSetErodeImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);           //purposely not implemented
-
   using DistanceImageType = typename Superclass::DistanceImageType;
 };
 } // end namespace itk

--- a/include/itkLabelSetMorphBaseImageFilter.h
+++ b/include/itkLabelSetMorphBaseImageFilter.h
@@ -48,6 +48,8 @@ class ITK_EXPORT LabelSetMorphBaseImageFilter:
   public ImageToImageFilter< TInputImage, TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(LabelSetMorphBaseImageFilter);
+
   /** Standard class type alias. */
   using Self = LabelSetMorphBaseImageFilter;
   using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
@@ -140,9 +142,6 @@ protected:
   // this is the first non-zero entry in the radius. Needed to
   // support elliptical operations
   RealType m_BaseSigma;
-private:
-  LabelSetMorphBaseImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);               //purposely not implemented
 };
 } // end namespace itk
 


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.