### PR TITLE
BUG: Fix test errors steming from the new multi-threading mechanism.

### DIFF
--- a/include/itkLabelSetDilateImageFilter.h
+++ b/include/itkLabelSetDilateImageFilter.h
@@ -77,10 +77,11 @@ public:
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
 protected:
-  LabelSetDilateImageFilter(){}
+  LabelSetDilateImageFilter()
+    { this->DynamicMultiThreadingOn(); }
   ~LabelSetDilateImageFilter() override {}
 
-  void ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId) override;
+  void DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
 
 private:
   using DistanceImageType = typename Superclass::DistanceImageType;

--- a/include/itkLabelSetDilateImageFilter.hxx
+++ b/include/itkLabelSetDilateImageFilter.hxx
@@ -32,7 +32,7 @@ namespace itk
 template< typename TInputImage, typename TOutputImage >
 void
 LabelSetDilateImageFilter< TInputImage, TOutputImage >
-::ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId)
+::DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread)
 {
   // this is where the work happens. We use a distance image with
   // floating point pixel to perform the parabolic operations. The
@@ -42,31 +42,6 @@ LabelSetDilateImageFilter< TInputImage, TOutputImage >
   // line copy.
   // Similarly, the thresholding on output needs to be integrated
   // with the last processing stage.
-  // stop warnings about unused argument
-  (void)threadId;
-  // compute the number of rows first, so we can setup a progress reporter
-  typename std::vector< unsigned int > NumberOfRows;
-  InputSizeType size   = outputRegionForThread.GetSize();
-
-  for ( unsigned int i = 0; i < InputImageDimension; i++ )
-    {
-    NumberOfRows.push_back(1);
-    for ( unsigned int d = 0; d < InputImageDimension; d++ )
-      {
-      if ( d != i )
-        {
-        NumberOfRows[i] *= size[d];
-        }
-      }
-    }
-  float progressPerDimension = 1.0 / ImageDimension;
-
-  auto *progress = new ProgressReporter(this,
-                                        threadId,
-                                        NumberOfRows[this->m_CurrentDimension],
-                                        30,
-                                        this->m_CurrentDimension * progressPerDimension,
-                                        progressPerDimension);
 
   using InputConstIteratorType = ImageLinearConstIteratorWithIndex< TInputImage  >;
   using OutputIteratorType = ImageLinearIteratorWithIndex< TOutputImage >;
@@ -112,7 +87,7 @@ LabelSetDilateImageFilter< TInputImage, TOutputImage >
       {
       LabSet::doOneDimensionDilateFirstPass< InputConstIteratorType, OutputDistIteratorType, OutputIteratorType,
                                              RealType >(inputIterator, outputDistIterator, outputIterator,
-                                                        *progress, LineLength,
+                                                        LineLength,
                                                         this->m_CurrentDimension,
                                                         this->m_MagnitudeSign,
                                                         this->m_UseImageSpacing,
@@ -130,7 +105,7 @@ LabelSetDilateImageFilter< TInputImage, TOutputImage >
                                                inputDistIterator,
                                                outputDistIterator,
                                                outputIterator,
-                                               *progress, LineLength,
+                                               LineLength,
                                                this->m_CurrentDimension,
                                                this->m_MagnitudeSign,
                                                this->m_UseImageSpacing,

--- a/include/itkLabelSetErodeImageFilter.h
+++ b/include/itkLabelSetErodeImageFilter.h
@@ -82,10 +82,11 @@ public:
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
 protected:
-  LabelSetErodeImageFilter(){}
+  LabelSetErodeImageFilter()
+    { this->DynamicMultiThreadingOn(); }
   ~LabelSetErodeImageFilter() override {}
 
-  void ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId) override;
+  void DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
 
   // Override since the filter produces the entire dataset.
 private:

--- a/include/itkLabelSetErodeImageFilter.hxx
+++ b/include/itkLabelSetErodeImageFilter.hxx
@@ -32,7 +32,7 @@ namespace itk
 template< typename TInputImage, typename TOutputImage >
 void
 LabelSetErodeImageFilter< TInputImage, TOutputImage >
-::ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId)
+::DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread)
 {
   // this is where the work happens. We use a distance image with
   // floating point pixel to perform the parabolic operations. The
@@ -46,26 +46,6 @@ LabelSetErodeImageFilter< TInputImage, TOutputImage >
   // compute the number of rows first, so we can setup a progress reporter
   typename std::vector< unsigned int > NumberOfRows;
   InputSizeType size   = outputRegionForThread.GetSize();
-
-  for ( unsigned int i = 0; i < InputImageDimension; i++ )
-    {
-    NumberOfRows.push_back(1);
-    for ( unsigned int d = 0; d < InputImageDimension; d++ )
-      {
-      if ( d != i )
-        {
-        NumberOfRows[i] *= size[d];
-        }
-      }
-    }
-  float progressPerDimension = 1.0 / ImageDimension;
-
-  auto *progress = new ProgressReporter(this,
-                                        threadId,
-                                        NumberOfRows[this->m_CurrentDimension],
-                                        30,
-                                        this->m_CurrentDimension * progressPerDimension,
-                                        progressPerDimension);
 
   using InputConstIteratorType = ImageLinearConstIteratorWithIndex< TInputImage  >;
   using OutputIteratorType = ImageLinearIteratorWithIndex< TOutputImage >;
@@ -107,7 +87,7 @@ LabelSetErodeImageFilter< TInputImage, TOutputImage >
       {
       LabSet::doOneDimensionErodeFirstPass< InputConstIteratorType, OutputDistIteratorType, OutputIteratorType,
                                             RealType >(inputIterator, outputDistIterator, outputIterator,
-                                                       *progress, LineLength,
+                                                       LineLength,
                                                        this->m_CurrentDimension,
                                                        this->m_MagnitudeSign,
                                                        this->m_UseImageSpacing,
@@ -127,7 +107,7 @@ LabelSetErodeImageFilter< TInputImage, TOutputImage >
                                               inputDistIterator,
                                               outputDistIterator,
                                               outputIterator,
-                                              *progress, LineLength,
+                                              LineLength,
                                               this->m_CurrentDimension,
                                               this->m_MagnitudeSign,
                                               this->m_UseImageSpacing,

--- a/include/itkLabelSetMorphBaseImageFilter.h
+++ b/include/itkLabelSetMorphBaseImageFilter.h
@@ -117,8 +117,7 @@ protected:
   RegionIndexType SplitRequestedRegion(RegionIndexType i, RegionIndexType num,
                                        OutputImageRegionType & splitRegion) override;
 
-  void ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread,
-                                    ThreadIdType threadId) override;
+  void DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
 
   void GenerateData(void) override;
 

--- a/include/itkLabelSetMorphBaseImageFilter.hxx
+++ b/include/itkLabelSetMorphBaseImageFilter.hxx
@@ -53,16 +53,17 @@ LabelSetMorphBaseImageFilter< TInputImage, doDilate, TOutputImage >
   m_UseImageSpacing = false;
 
   this->SetRadius(1);
+
+  this->DynamicMultiThreadingOn();
 }
 
 template< typename TInputImage, bool doDilate, typename TOutputImage >
 void
 LabelSetMorphBaseImageFilter< TInputImage, doDilate, TOutputImage >
-::ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId)
+::DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread)
 {
   // stop warnings
   (void)outputRegionForThread;
-  (void)threadId;
 }
 
 template< typename TInputImage, bool doDilate, typename TOutputImage >

--- a/include/itkLabelSetUtils.h
+++ b/include/itkLabelSetUtils.h
@@ -20,7 +20,6 @@
 
 #include <itkArray.h>
 
-#include "itkProgressReporter.h"
 #include <vector>
 namespace itk
 {
@@ -225,7 +224,6 @@ void DoLineLabelProp(LineBufferType & LineBuf, LineBufferType & tmpLineBuf,
 template< class TInIter, class TOutDistIter, class TOutLabIter, class RealType >
 void doOneDimensionErodeFirstPass(TInIter & inputIterator, TOutDistIter & outputIterator,
                                   TOutLabIter & outputLabIterator,
-                                  ProgressReporter & progress,
                                   const unsigned LineLength,
                                   const unsigned direction,
                                   const int m_MagnitudeSign,
@@ -350,14 +348,12 @@ void doOneDimensionErodeFirstPass(TInIter & inputIterator, TOutDistIter & output
     // now onto the next line
     inputIterator.NextLine();
     outputIterator.NextLine();
-    progress.CompletedPixel();
     }
 }
 
 template< class TInIter, class TOutDistIter, class TOutLabIter, class RealType >
 void doOneDimensionDilateFirstPass(TInIter & inputIterator, TOutDistIter & outputIterator,
                                    TOutLabIter & outputLabIterator,
-                                   ProgressReporter & progress,
                                    const unsigned LineLength,
                                    const unsigned direction,
                                    const int m_MagnitudeSign,
@@ -436,14 +432,12 @@ void doOneDimensionDilateFirstPass(TInIter & inputIterator, TOutDistIter & outpu
     inputIterator.NextLine();
     outputIterator.NextLine();
     outputLabIterator.NextLine();
-    progress.CompletedPixel();
     }
 }
 
 template< class TInIter, class TDistIter, class TOutLabIter, class TOutDistIter, class RealType >
 void doOneDimensionErode(TInIter & inputIterator, TDistIter & inputDistIterator,
                          TOutDistIter & outputDistIterator, TOutLabIter & outputLabIterator,
-                         ProgressReporter & progress,
                          const unsigned LineLength,
                          const unsigned direction,
                          const int m_MagnitudeSign,
@@ -568,14 +562,12 @@ void doOneDimensionErode(TInIter & inputIterator, TDistIter & inputDistIterator,
     inputIterator.NextLine();
     inputDistIterator.NextLine();
     outputDistIterator.NextLine();
-    progress.CompletedPixel();
     }
 }
 
 template< class TInIter, class TDistIter, class TOutLabIter, class TOutDistIter, class RealType >
 void doOneDimensionDilate(TInIter & inputIterator, TDistIter & inputDistIterator,
                           TOutDistIter & outputDistIterator, TOutLabIter & outputLabIterator,
-                          ProgressReporter & progress,
                           const unsigned LineLength,
                           const unsigned direction,
                           const int m_MagnitudeSign,
@@ -652,7 +644,6 @@ void doOneDimensionDilate(TInIter & inputIterator, TDistIter & inputDistIterator
     outputLabIterator.NextLine();
     inputDistIterator.NextLine();
     outputDistIterator.NextLine();
-    progress.CompletedPixel();
     }
 }
 }


### PR DESCRIPTION
Fix errors steming from the use of the new `itk::PoolMultiThreader`
class for multi-threading.

The errors stemmed when this gerrit topic got merged:
http://review.source.kitware.com/#/c/23175/

And were later related to the following gerrit-topic:
http://review.source.kitware.com/#/c/23434/

The solution adopted in this patch set was based on the proposal in:
http://review.source.kitware.com/#/c/23439/