### PR TITLE
BUG: Fix unused variable CDash warnings.

### DIFF
--- a/include/itkLabelSetErodeImageFilter.hxx
+++ b/include/itkLabelSetErodeImageFilter.hxx
@@ -43,10 +43,6 @@ LabelSetErodeImageFilter< TInputImage, TOutputImage >
   // Similarly, the thresholding on output needs to be integrated
   // with the last processing stage.
 
-  // compute the number of rows first, so we can setup a progress reporter
-  typename std::vector< unsigned int > NumberOfRows;
-  InputSizeType size   = outputRegionForThread.GetSize();
-
   using InputConstIteratorType = ImageLinearConstIteratorWithIndex< TInputImage  >;
   using OutputIteratorType = ImageLinearIteratorWithIndex< TOutputImage >;
 


### PR DESCRIPTION
Fix the unused variable CDash warnings reported in:
https://open.cdash.org/viewBuildError.php?type=1&buildid=5401884
and issued by the builds triggered in the following gerrit topic:
http://review.source.kitware.com/#/c/23434/

Also, take advantage to remove the unused `NumberOfRows` `typename` in the
same file. Moreover, the new multi-threading framework does not require
the filters to declare and update variables to report their progress.